### PR TITLE
experimental references/circular-deps support

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,8 +1,12 @@
 
 const format = require('./')
 
-console.log(format({
+const a = { a: 1 }
+
+let tree = {
   message: 'hello world',
+  a,
+  b: a,
   dev: true,
   list: [
     "hello",
@@ -17,4 +21,8 @@ console.log(format({
     some: undefined,
     props: false
   }
-}))
+}
+
+tree.body.circular = tree.body
+
+console.log(format(tree))

--- a/example.js
+++ b/example.js
@@ -9,8 +9,8 @@ let tree = {
   b: a,
   dev: true,
   list: [
-    "hello",
-    "it's",
+    'hello',
+    'it\'s',
     { key: 'val', some: 'string' }
   ],
   alwaysTrue: () => true,

--- a/index.js
+++ b/index.js
@@ -71,9 +71,11 @@ const createRefMap = () => {
   }
 }
 
-const searchForRef = createRefMap()
-
-const formatWithDepth = (obj, formatter, { path, depth, offset }) => {
+const formatWithDepth = (
+  obj,
+  formatter,
+  { lookupRef, path, depth, offset }
+) => {
   const keys = Object.keys(obj)
   const coloredKeys = keys.map((key) => formatter.property(key))
   const colon = ': '
@@ -82,7 +84,7 @@ const formatWithDepth = (obj, formatter, { path, depth, offset }) => {
     const nextPath = path.concat([key])
     const val = obj[key]
 
-    const ref = searchForRef(
+    const ref = lookupRef(
       nextPath,
       val,
       (npath) => formatCircular(formatter, npath)
@@ -105,7 +107,8 @@ const formatWithDepth = (obj, formatter, { path, depth, offset }) => {
       out += formatWithDepth(val, formatter, {
         offset: offset + longest(keys).length + colon.length,
         depth: { curr: depth.curr + 1, max: depth.max },
-        path: nextPath
+        path: nextPath,
+        lookupRef
       })
     } else {
       out += formatValue(formatter, val)
@@ -133,6 +136,7 @@ const format = (
   offset = 2
 ) => formatWithDepth(obj, formatter, {
   depth: { curr: 0, max: depth },
+  lookupRef: createRefMap(),
   path: [],
   offset
 })

--- a/index.js
+++ b/index.js
@@ -4,8 +4,6 @@ const longest = require('longest')
 const chalk = require('chalk')
 const tsml = require('tsml')
 
-const isCircular = (val) => /^~/.test(val)
-
 const isPlainObj = (o) =>
   o !== null && typeof o === 'object' && o.constructor === Object
 

--- a/test.js
+++ b/test.js
@@ -63,3 +63,27 @@ test('depth', (t) => {
   t.true(fmtOneLevel.includes('b: true'))
   t.false(fmtOneLevel.includes('d: true'))
 })
+
+test('references', (t) => {
+  const c = { prop: true }
+  const actual = {
+    a: c,
+    b: c
+  }
+
+  const fmt = format(actual)
+  t.true(fmt.includes('References ~a'))
+})
+
+test('circular', (t) => {
+  let actual = {
+    body: {
+      a: true
+    }
+  }
+
+  actual.body.b = actual.body
+
+  const fmt = format(actual)
+  t.true(fmt.includes('References ~body'))
+})


### PR DESCRIPTION
Regarding #3, @jordonbiondo

This PR visualizes cyclic structures. It'll replace any reference with an annotation of where it has seen it first. If we have two keys `a` and `b` both pointing to `c` then it'll look like

**js**
```js
const c = { prop: 'string' }
console.log(format({ a: c, b: c }))
```

**output**
```bash
a: { prop: 'string' }
b: [References ~a]
```

This is not a cyclic structure. However, because we can't have proper cyclic structure detection in javascript as far as I know, this is a fair compromise.

Let me know what you think!